### PR TITLE
Adjust echo pid line to be compatible with (mimc) output from OpenSSH ssh-agent

### DIFF
--- a/linux/main.c
+++ b/linux/main.c
@@ -856,7 +856,7 @@ main(int argc, char *argv[])
             err(1, "kill(%d)", pid);
         output_unset_env(opt_sh);
         if (!opt_quiet)
-            printf("echo ssh-agent-wsl pid %d killed;\n", pid);
+            printf("echo Agent pid %d killed;\n", pid);
         return 0;
     }
 
@@ -944,7 +944,7 @@ main(int argc, char *argv[])
             output_set_env(opt_sh, p_set_pid_env, escaped_sockpath, pid);
             free(escaped_sockpath);
             if (p_set_pid_env && !opt_quiet)
-                printf("echo ssh-agent-wsl pid %d;\n", pid);
+                printf("echo Agent pid %d;\n", pid);
             if (p_daemonize)
                 return 0;
         }


### PR DESCRIPTION
OpenSSH `ssh-agent` echoes "Agent pid _n_" when starting up, whereas `ssh-agent-wsl` says "ssh-agent-wsl pid _n_".

I am using `ssh-agent-wsl` with [Keychain](https://www.funtoo.org/Keychain) (by renaming the `ssh-agent-wsl` binary as `ssh-agent`), which specifically greps for 'Agent pid' in the output from `ssh-agent`. This causes problems (at least in my Fish shell) since the "ssh-agent-wsl pid n" line escapes Keychain's filtering and the shell tries to evaluate it.

It would ease compatibility, and allow `ssh-agent-wsl` to be a drop-in replacement for `ssh-agent`, if `ssh-agent-wsl` also said "Agent pid _n_" instead. This pull request implements that. Would you consider it?